### PR TITLE
make 'python setup.py install' work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,13 @@ from distutils.core import setup
 from Cython.Build import cythonize
 import numpy as np
 
-setup(name='gslrng',
+setup(name='gslrandom',
       version='0.1',
       description='Cython wrappers for GSL random number generators',
       author='Scott Linderman and Aaron Schein',
       author_email='slinderman@seas.harvard.edu',
-      url='http://www.github.com/slinderman/gslrng',
+      url='http://www.github.com/slinderman/gslrandom',
+      packages=['gslrandom'],
       ext_modules=cythonize('**/*.pyx'),
       include_dirs=[np.get_include(),],
      )


### PR DESCRIPTION
I updated the name from "gslrng" to "gslrandom" and also added the packages argument so that the command `python setup.py install` should work.
